### PR TITLE
Fixed potential binarysearch error

### DIFF
--- a/BinarySearch.java
+++ b/BinarySearch.java
@@ -13,7 +13,7 @@ public class BinarySearch {
 		int x = sc.nextInt();
 		
 		do{
-			mid = (high+low)/2;
+			mid = low + (high-low)/2;
 			
 			if (array[mid] == x){
 				System.out.println(x+" is at "+(mid+1));


### PR DESCRIPTION
Hello there! You have a common error in your Binary Search implementation. 

`(L + R) / 2` can result in an arithmetic overflow if L and R are sufficiently large. Instead, you can use `L + (R - L) / 2` which will not overflow as long as L & R are non-negative.

The algorithm will still work if L & R can be negative but it will unfortunately increase the likelyhood of overflow for when R is very positive and L is very negative. You are advised to **accept this PR if L and R are guaranteed to be positive** or if you want to impress your professor with how smart you are.

See [Wikipedia](https://en.wikipedia.org/wiki/Binary_search_algorithm#Implementation_issues) for more information. This action was performed semi-automatically, just like an M14.